### PR TITLE
Log DB errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /dev
+*.DS_Store

--- a/examples/oidc.rs
+++ b/examples/oidc.rs
@@ -28,13 +28,20 @@ async fn main() {
 
     // OIDC
     let tls_conf = conf.tls.as_ref().expect("Must define TLS for this example");
-    let oidc_conf = conf.oidc.as_ref().expect("Must define OIDC for this example");
+    let oidc_conf = conf
+        .oidc
+        .as_ref()
+        .expect("Must define OIDC for this example");
 
     init_client_pool(tls_conf.ca_path.as_str());
     let redirect_url = "https://localhost:8443/auth";
     let oidc = OidcCredentials::new(
         oidc_conf.client_id.clone(),
-        oidc_conf.client_secret.as_ref().expect("No OIDC Client Secret").clone(),
+        oidc_conf
+            .client_secret
+            .as_ref()
+            .expect("No OIDC Client Secret")
+            .clone(),
         redirect_url,
     )
     .expect("Invalid OIDC Credentials");

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -23,7 +23,10 @@ async fn main() {
     let conf: InnerConfig = conf
         .try_into()
         .expect("Could not fetch all secrets from environment");
-    let tls_conf = conf.tls.as_ref().expect("Must define TLS conf for this example");
+    let tls_conf = conf
+        .tls
+        .as_ref()
+        .expect("Must define TLS conf for this example");
 
     // Routes
     let session = init_session_store();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use reqwest::header::{HeaderMap, HeaderValue};
 use tokio::sync::broadcast;
-use warp::{Filter, Reply, http::StatusCode};
+use warp::{http::StatusCode, Filter, Reply};
 use warp_sessions::MemoryStore;
 
 pub mod sessions;
@@ -63,7 +63,10 @@ pub async fn handle_rejection(
     err: warp::reject::Rejection,
 ) -> Result<Box<dyn warp::Reply>, std::convert::Infallible> {
     if err.is_not_found() {
-        return Ok(Box::new(warp::reply::with_status("NOT_FOUND", StatusCode::NOT_FOUND)));
+        return Ok(Box::new(warp::reply::with_status(
+            "NOT_FOUND",
+            StatusCode::NOT_FOUND,
+        )));
     }
 
     if let Some(_) = err.find::<NoSessionToken>() {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,7 +20,14 @@ pub struct ConflictError {}
 impl warp::reject::Reject for ConflictError {}
 
 #[derive(Debug)]
-pub struct DatabaseError {}
+pub struct DatabaseError {
+    pub msg: String,
+}
+impl DatabaseError {
+    pub fn new(msg: String) -> Self {
+        Self { msg }
+    }
+}
 impl warp::reject::Reject for DatabaseError {}
 
 #[derive(Debug)]
@@ -105,7 +112,7 @@ pub async fn handle_rejection(
         return Ok(Box::new(response));
     }
     if let Some(db_err) = err.find::<DatabaseError>() {
-        tracing::error!("DB Error: {:?}", db_err);
+        tracing::error!("DB Error: {:?}", db_err.msg);
         let json = warp::reply::json(&"Database Error");
         let response =
             warp::reply::with_status(json, warp::http::StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -26,7 +26,7 @@ pub async fn create_user_handler<U: UserTable>(
 ) -> Result<(impl warp::Reply, SessionWithStore<MemoryStore>), warp::Rejection> {
     let mut conn = match db_pool.get() {
         Ok(conn) => conn,
-        Err(_) => return Err(warp::reject::custom(DatabaseError {})),
+        Err(err) => return Err(warp::reject::custom(DatabaseError::new(err.to_string()))),
     };
     let UserPayload { username, email } = payload;
     let opt_username = match &username {
@@ -49,7 +49,7 @@ pub async fn get_user_handler<U: UserTable>(
 ) -> Result<(impl warp::Reply, SessionWithStore<MemoryStore>), warp::Rejection> {
     let mut conn = match db_pool.get() {
         Ok(conn) => conn,
-        Err(_) => return Err(warp::reject::custom(DatabaseError {})),
+        Err(err) => return Err(warp::reject::custom(DatabaseError::new(err.to_string()))),
     };
     let user = match U::get(&mut conn, user_id) {
         Some(user) => user,

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,9 +1,9 @@
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use uuid::Uuid;
 use warp::{Filter, Rejection, Reply};
 use warp_sessions::{MemoryStore, SessionWithStore};
-use uuid::Uuid;
 
 use super::*;
 use crate::api::sessions::store_auth_cookie;
@@ -45,7 +45,7 @@ pub async fn get_user_handler<U: UserTable>(
     user_id: Uuid,
     _auth_user: AuthenticatedUser,
     session: SessionWithStore<MemoryStore>,
-    db_pool: Arc<DbPool>
+    db_pool: Arc<DbPool>,
 ) -> Result<(impl warp::Reply, SessionWithStore<MemoryStore>), warp::Rejection> {
     let mut conn = match db_pool.get() {
         Ok(conn) => conn,
@@ -53,9 +53,7 @@ pub async fn get_user_handler<U: UserTable>(
     };
     let user = match U::get(&mut conn, user_id) {
         Some(user) => user,
-        None => {
-            return Err(warp::reject::custom(NotFoundError{}))
-        }
+        None => return Err(warp::reject::custom(NotFoundError {})),
     };
     Ok((warp::reply::json(&user), session))
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,19 +1,19 @@
-use std::str::FromStr;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Once;
 
 use anyhow::{anyhow, Result as AnyResult};
 use openidconnect::core::{
     CoreAuthenticationFlow, CoreClient, CoreIdToken, CoreIdTokenClaims, CoreProviderMetadata,
-    CoreTokenResponse
+    CoreTokenResponse,
 };
 use openidconnect::reqwest::Error as RequestError;
 use openidconnect::{
     AccessToken, AccessTokenHash, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
     HttpRequest, HttpResponse, IssuerUrl, Nonce, OAuth2TokenResponse, PkceCodeChallenge,
-    PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse 
+    PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse,
 };
 use reqwest::{redirect::Policy, Certificate, Client};
 use rustls_pemfile::certs;
@@ -113,21 +113,21 @@ impl OidcToken {
             id_token: token.id_token().cloned()?,
             access_token: token.access_token().clone(),
             refresh_token: token.refresh_token().cloned(),
-            nonce: self.nonce
+            nonce: self.nonce,
         })
     }
 
     pub fn from_bearer(tok: &str) -> Option<Self> {
         let parts: Vec<&str> = tok.split(':').collect();
         if parts.len() == 3 {
-            Some(OidcToken{
+            Some(OidcToken {
                 id_token: CoreIdToken::from_str(parts[0]).ok()?,
                 access_token: AccessToken::new(parts[1].to_string()),
                 refresh_token: None,
                 nonce: Nonce::new(parts[2].to_string()),
             })
         } else if parts.len() == 4 {
-            Some(OidcToken{
+            Some(OidcToken {
                 id_token: CoreIdToken::from_str(parts[0]).ok()?,
                 access_token: AccessToken::new(parts[1].to_string()),
                 refresh_token: Some(RefreshToken::new(parts[2].to_string())),
@@ -181,15 +181,16 @@ impl IdentityProvider {
     pub async fn refresh(&self, token: OidcToken) -> AnyResult<OidcToken> {
         let refresh_token = match &token.refresh_token {
             Some(tok) => tok,
-            None => anyhow::bail!("No refresh token")
+            None => anyhow::bail!("No refresh token"),
         };
-        let token_response = self.client
+        let token_response = self
+            .client
             .exchange_refresh_token(refresh_token)
             .request_async(async_http_client)
             .await?;
         match token.refresh(token_response) {
             Some(token) => Ok(token),
-            None => anyhow::bail!("Missing token")
+            None => anyhow::bail!("Missing token"),
         }
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,12 +9,15 @@ pub const ROUTER_MESSAGE_LIMIT: usize = 1024;
 /// custom types to clarify the rx/tx relationship.
 pub struct Router {
     broadcast_map: AnyMap,
-    mpsc_map: AnyMap
+    mpsc_map: AnyMap,
 }
 
 impl Router {
     pub fn new() -> Self {
-        Self { broadcast_map: AnyMap::new(), mpsc_map: AnyMap::new() }
+        Self {
+            broadcast_map: AnyMap::new(),
+            mpsc_map: AnyMap::new(),
+        }
     }
 
     pub fn subscribe<M: Send + Sync + Clone + 'static>(&mut self) -> broadcast::Receiver<M> {
@@ -41,13 +44,17 @@ impl Router {
         self.mpsc_map.get::<mpsc::Sender<M>>()
     }
 
-    pub fn create_unbounded_channel<M: Send + Sync + 'static>(&mut self) -> mpsc::UnboundedReceiver<M> {
+    pub fn create_unbounded_channel<M: Send + Sync + 'static>(
+        &mut self,
+    ) -> mpsc::UnboundedReceiver<M> {
         let (tx, rx) = mpsc::unbounded_channel();
         self.mpsc_map.insert::<mpsc::UnboundedSender<M>>(tx);
         rx
     }
 
-    pub fn get_unbounded_address<M: Send + Sync + 'static>(&self) -> Option<&mpsc::UnboundedSender<M>> {
+    pub fn get_unbounded_address<M: Send + Sync + 'static>(
+        &self,
+    ) -> Option<&mpsc::UnboundedSender<M>> {
         self.mpsc_map.get::<mpsc::UnboundedSender<M>>()
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -37,10 +37,5 @@ pub mod auth {
     diesel::joinable!(portraits -> users (user_id));
     diesel::joinable!(user_id_accounts -> users (user_id));
 
-    diesel::allow_tables_to_appear_in_same_query!(
-        metadata,
-        portraits,
-        user_id_accounts,
-        users,
-    );
+    diesel::allow_tables_to_appear_in_same_query!(metadata, portraits, user_id_accounts, users,);
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,5 +1,5 @@
-use tracing_subscriber::prelude::*;
 use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::prelude::*;
 
 pub fn setup_tracing(app_name: &str) {
     #[cfg(debug_assertions)]


### PR DESCRIPTION
Restarting zini pod triggers creation of system user and default flow:
```
sol@Nemesis orchard % kubectl -n subseq delete pod/zini-5bc4f68bf6-tgfpw 
pod "zini-5bc4f68bf6-tgfpw" deleted
sol@Nemesis orchard % kubectl -n subseq logs zini-5bc4f68bf6-r95dh -f   
2024-04-18T18:17:33.996395Z  INFO subseq_util::tracing: App 'zini' started
Created Flow: {"id":"f2e91c88-78b2-4999-ab79-3b2cb998ba7a","owner_id":"00000000-0000-0000-0000-000000000000","created":"2024-04-18T18:17:34.037393086","flow_name":"DEFAULT","description":"This is the default flow","entry_node_id":"b8a0f4aa-63eb-4fab-80bf-d86cc485ec46"}
Entry Node: {"id":"b8a0f4aa-63eb-4fab-80bf-d86cc485ec46","node_name":"OPEN"}
Exit Node: {"id":"10411d66-8b8e-4cd7-a9e3-cf5dc8b5a3b8","node_name":"CLOSED"}
2024-04-18T18:17:34.042063Z  INFO subseq_util::oidc: OIDC server: https://keycloak.subsequent.corp/realms/agents
```

Restarting second time seed data is skipped.
```
sol@Nemesis orchard % kubectl -n subseq delete pod/zini-5bc4f68bf6-r95dh 
pod "zini-5bc4f68bf6-r95dh" deleted
sol@Nemesis orchard % kubectl -n subseq logs zini-5bc4f68bf6-n45j7 -f   
2024-04-18T20:11:33.690159Z  INFO subseq_util::tracing: App 'zini' started
2024-04-18T20:11:33.726145Z  INFO subseq_util::oidc: OIDC server: https://keycloak.subsequent.corp/realms/agents
2024-04-18T20:11:33.735238Z  INFO zini::events: Zini connected to prism!
2024-04-18T20:12:02.581028Z  INFO zini: 10.244.0.5:58958 GET /ws 101 Switching Protocols
2024-04-18T20:12:02.581273Z  INFO zini::api::socket: Client 89f365ab-3823-4961-a21c-538b500468e5 ws started
2024-04-18T20:12:02.581409Z  INFO zini::api::prompts: New instruction channel
```