### PR TITLE
Support a query param for /auth/login?origin so we can get redirects working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ dependencies = [
  "diesel_migrations",
  "email_address",
  "function_name",
+ "hyper",
  "lazy_static",
  "openidconnect",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ diesel = { version = "2.2.1", features = ["chrono", "r2d2", "postgres", "postgre
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 email_address = "0.2.4"
 function_name = "0.3.0"
+hyper = { version = "0.14", features = ["http2"] }
 lazy_static = "1.4.0"
 openidconnect = "3.4.0"
 rand = "0.8.5"


### PR DESCRIPTION
Also: Don't fail logins on mismatches anymore, just redirect back to /auth/login -- this is necessary for certain events where we get logged in directly from the login page without having a token from the server. By going to the login portal we regenerate a token and then authorize it in another loop to make sure this request was valid.