### PR TITLE
Fully qualify connection trait

### DIFF
--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -41,10 +41,9 @@ pub fn init_cert_pool<P: Into<PathBuf>>(ca_path: Option<P>) {
                 .expect("CA file could not be read");
 
             certs.push(Certificate::from_pem(&buf).expect("Invalid certificate"));
-            for cert in rustls_pemfile::certs(&mut &buf[..]) {
-                if let Ok(cert) = cert {
-                    der_certs.push(cert);
-                }
+
+            for cert in rustls_pemfile::certs(&mut &buf[..]).flatten() {
+                der_certs.push(cert);
             }
         }
         unsafe {

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -54,5 +54,8 @@ pub fn init_cert_pool<P: Into<PathBuf>>(ca_path: Option<P>) {
 }
 
 pub fn get_cert_pool() -> Option<&'static CertPool> {
-    unsafe { CERT_POOL.as_ref() }
+    #[allow(static_mut_refs)]
+    unsafe {
+        CERT_POOL.as_ref()
+    }
 }

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -200,7 +200,11 @@ pub mod harness {
         let url = url.to_string();
         spawn(
             move || -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-                let mut connection = AsyncConnectionWrapper::<AsyncPgConnection>::establish(&url)?;
+                let mut connection =
+                    <AsyncConnectionWrapper<AsyncPgConnection> as diesel::Connection>::establish(
+                        &url,
+                    )?;
+
                 for mig in <EmbeddedMigrations as MigrationSource<Pg>>::migrations(&AUTH_MIGRATIONS)
                     .unwrap()
                 {


### PR DESCRIPTION
When building zini, I was getting an error due to conflicting `establish` trait methods:

```
error[E0034]: multiple applicable items in scope
   --> src/tables/mod.rs:203:83
    |
203 | ...cPgConnection>::establish(&url)?;
    |                    ^^^^^^^^^ multiple `establish` found
    |
    = note: candidate #1 is defined in an impl of the trait `diesel::Connection` for the type `async_connection_wrapper::implementation::AsyncConnectionWrapper<C, B>`
    = note: candidate #2 is defined in an impl of the trait `AsyncConnection` for the type `C`
help: use fully-qualified syntax to disambiguate
    |
203 |                 let mut connection = <async_connection_wrapper::implementation::AsyncConnectionWrapper<AsyncPgConnection, async_connection_wrapper::implementation::Tokio> as AsyncConnection>::establish(&url)?;
    |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
203 |                 let mut connection = <async_connection_wrapper::implementation::AsyncConnectionWrapper<AsyncPgConnection, async_connection_wrapper::implementation::Tokio> as diesel::Connection>::establish(&url)?;
    |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This change qualifies the `AsyncConnectionWrapper` as a `diesel::Connection` to resolve the error.

Also silences the shared mutable reference warning in `rustls::get_cert_pool` and addresses a Clippy warning.